### PR TITLE
@fix/duplicate api call

### DIFF
--- a/src/api/modules/ExchangeRateApi.ts
+++ b/src/api/modules/ExchangeRateApi.ts
@@ -12,8 +12,6 @@ export const ExchangeRateAPI = {
       `/exchange-rates/current`,
       {
         baseCurrency,
-        page,
-        limit,
       }
     );
 

--- a/src/hooks/useExchangeRate.ts
+++ b/src/hooks/useExchangeRate.ts
@@ -1,5 +1,5 @@
 // hooks/useExchangeRate.ts
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { ExchangeRateAPI } from "../api/modules/ExchangeRateApi";
 import {
   RateDetailDto,
@@ -112,10 +112,12 @@ export const useExchangeRate = (
     }
   };
 
+  const hasFetched = useRef(false);
   useEffect(() => {
-    if (isAuthenticated) {
-      fetchRates();
-    }
+    if (!isAuthenticated || hasFetched.current) return;
+    hasFetched.current = true;
+
+    fetchRates();
   }, [isAuthenticated, baseCurrency]);
 
   const handleBaseCurrencyChange = (newCurrency: string) => {


### PR DESCRIPTION
As the baseCurrency state was initialized, the API used useRef to prevent duplicate calls
